### PR TITLE
Allow additional args to headless-build.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 stm32cubeide --launcher.suppressErrors -nosplash -application org.eclipse.cdt.managedbuilder.core.headlessbuild -data /tmp/stm-workspace -import "$1"
-headless-build.sh -data /tmp/stm-workspace -build "$2"
+headless-build.sh -data /tmp/stm-workspace -build "$2" "${@:3}"


### PR DESCRIPTION
This allows passing in extra defines etc when
used via github actions
