### PR TITLE
Make the git command available for pre-build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM xanderhendriks/stm32cubeide:12.0
 
 RUN apt-get -y update && \
-    apt-get -y install curl python3 python3-pip && \
+    apt-get -y install curl python3 python3-pip git && \
     ln -s $(which python3) /usr/bin/python
 
 # The requirements.txt comes from the Middlewares\ST\STM32_Secure_Engine\Utilities\KeysAndImages\ directory


### PR DESCRIPTION
We want to automatically generate version information during our builds. In order for this to work seamlessly both for CI-builds as well as local dev builds, we aim to do this using a pre-build step in the Cube IDE. During this step we need the git command, so we would like have it available in the CI action as well.