### PR TITLE
Updated STMCubeIde 1.19.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM xanderhendriks/stm32cubeide:15.1
+FROM xanderhendriks/stm32cubeide:16.0
 
 # The requirements come from the Middlewares\ST\STM32_Secure_Engine\Utilities\KeysAndImages\ directory
 # in the sitehive-stm32-sbsfu repo

--- a/README.md
+++ b/README.md
@@ -52,5 +52,6 @@ The major.minor version number indicates the version of the underlying [STM32Cub
 - 14.0: STM32 Cube IDE: 1.17.0
 - 15.0: STM32 Cube IDE: 1.18.0 - Using -importAll
 - 15.1: STM32 Cube IDE: 1.18.1 - Using -importAll
+- 16.0: STM32 Cube IDE: 1.19.0 - Using -importAll
 
 NOTE: Bug fixes are only implemented for older versions if requested.


### PR DESCRIPTION
Proposed support for STMCubeIde v1.19.0 using the docker image that need to be generated with the other proposed pull request on repository docker-stm32cubeide