### PR TITLE
Disable the indexer

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-stm32cubeide --launcher.suppressErrors -nosplash -application org.eclipse.cdt.managedbuilder.core.headlessbuild -data /tmp/stm-workspace -importAll "$1"
-headless-build.sh -data /tmp/stm-workspace -build "$2"
+stm32cubeide --launcher.suppressErrors -nosplash -application org.eclipse.cdt.managedbuilder.core.headlessbuild -no-indexer -data /tmp/stm-workspace -importAll "$1"
+headless-build.sh -no-indexer -data /tmp/stm-workspace -build "$2"


### PR DESCRIPTION
By default, the indexer runs also in headless mode. Disabling it, can significantly improve build times for larger projects.